### PR TITLE
Add a new signature (just pass in a string) and use can-define to set up List and Map if they’re not passed in

### DIFF
--- a/can-rest-model-test.js
+++ b/can-rest-model-test.js
@@ -157,3 +157,10 @@ QUnit.test("CRUD basics", 10, function(assert){
     });
 
 });
+
+QUnit.test("string signature", function(assert) {
+    var connection = restModel("/api/todos/{_id}");
+
+    assert.ok(new connection.Map() instanceof DefineMap, "Map defined");
+    assert.ok(new connection.List() instanceof DefineList, "List defined");
+});

--- a/can-rest-model.js
+++ b/can-rest-model.js
@@ -2,10 +2,24 @@ var constructor = require("can-connect/constructor/constructor");
 var canMap = require("can-connect/can/map/map");
 var dataParse = require("can-connect/data/parse/parse");
 var dataUrl = require("can-connect/data/url/url");
+var DefineList = require("can-define/list/list");
+var DefineMap = require("can-define/map/map");
 var namespace = require("can-namespace");
 var base = require("can-connect/base/base");
 
-function restModel(options){
+function restModel(optionsOrUrl) {
+
+	// If optionsOrUrl is a string, make options = {url: optionsOrUrl}
+	var options = (typeof optionsOrUrl === "string") ? {url: optionsOrUrl} : optionsOrUrl;
+
+	// If options.Map or .List aren’t provided, define them
+	if (typeof options.Map === "undefined") {
+		options.Map = DefineMap.extend({seal: false}, {});
+	}
+	if (typeof options.List === "undefined") {
+		options.List = options.Map.List || DefineList.extend({"#": options.Map});
+	}
+
 	var connection = [base,dataUrl, dataParse, constructor, canMap].reduce(function(prev, behavior){
 		return behavior(prev);
 	}, options);

--- a/can-rest-model.md
+++ b/can-rest-model.md
@@ -1,6 +1,7 @@
 @module {function} can-rest-model
 @parent can-data-modeling
 @collection can-core
+@package ./package.json
 @outline 2
 
 Connect a type to a restful service layer.
@@ -89,6 +90,37 @@ Todo.getList().then(todos => {
   type. This is built automatically from the `Map` if [can-define/map/map] is used.
 
 @return {connection} Returns a connection object.
+
+@signature `restModel(url)`
+
+Create a connection with just a url. Use this if you do not need to pass in any other `options` to configure the connection.
+
+For example, the following creates a `Todo` type with the ability to connect to a restful service layer:
+
+```js
+import {todoFixture} from "//unpkg.com/can-demo-models@5";
+import {restModel} from "can";
+
+// Creates a mock backend with 5 todos
+todoFixture(5);
+
+const Todo = restModel("/api/todos/{id}").Map;
+
+// Prints out all todo names
+Todo.getList().then(todos => {
+    todos.forEach(todo => {
+        console.log(todo.name);
+    })
+})
+```
+  @codepen
+
+@param {String} url The [can-connect/data/url/url.url] used to create, retrieve, update and
+  delete data.
+
+@return {connection} A connection that is the combination of the options and all the behaviors
+that `restModel` adds. The `connection` includes a `Map` property which is the type
+constructor function used to create instances of the raw record data retrieved from the server.
 
 @body
 
@@ -314,7 +346,7 @@ Todo.getList().then(todos => console.log(todos[0].subtasks[0].completed));
 ```
   @highlight 10-12
   @codepen
- 
+
 
 #### The identity property
 

--- a/package.json
+++ b/package.json
@@ -40,15 +40,15 @@
     ]
   },
   "dependencies": {
-    "can-connect": "^3.0.0-pre.0",
+    "can-connect": "^3.0.0",
+    "can-define": "^2.2.0",
     "can-globals": "^1.0.1",
     "can-namespace": "^1.0.0",
     "can-query-logic": "<2.0.0",
     "can-reflect": "^1.15.2"
   },
   "devDependencies": {
-    "can-fixture": "^3.0.0-pre.3",
-    "can-define": "^2.2.0",
+    "can-fixture": "^3.0.0",
     "jshint": "^2.9.1",
     "steal": "^1.6.5",
     "steal-qunit": "^1.0.1",


### PR DESCRIPTION
This makes the following possible:

```js
const Todo = restModel("/api/todos/{id}").Map;
```

- Pass in just a string to `restModel()` to configure the connection
- If `Map` or `List` aren’t defined in the options, then `can-define` is used by default

Closes https://github.com/canjs/can-rest-model/issues/4

Here’s the new signature:
<img width="941" alt="screen shot 2019-02-22 at 2 40 38 pm" src="https://user-images.githubusercontent.com/10070176/53275410-e4f5c700-36af-11e9-8076-f52b72b5606e.png">
